### PR TITLE
Add docker managed volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-data
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Because I've oft needed them, particularly when I just don't wanna deal with the
 Clone the repo or copy a `docker-compose.yml` file to your system, `cd` into that directory, and turn it on with `docker-compose up`. For a full reference on how to use Docker Compose, [go here](https://docs.docker.com/compose/reference/).
 
 ## Local Persistence
-In each setup, your data is configured to be stored locally in a `./data` directory. If that directory doesn't exist, it'll be created automatically.
+In each setup a docker managed volume is created to persist the database. This can be deleted by Docker compose by passing the "-v" option when deleting the container(s).
+
+```
+docker-compose down -v
+```
 
 ## Authentication
 For authenticating as super user with each of these examples, `root` should be the username and `password` should be the password.

--- a/mongo/docker-compose.yml
+++ b/mongo/docker-compose.yml
@@ -4,9 +4,12 @@ services:
   db:
     image: mongo:latest
     volumes:
-      - ./data:/data/db
+      - dbdata:/data/db
     ports:
       - 27017:27017
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: password
+
+volumes:
+  dbdata:

--- a/mysql/docker-compose.yml
+++ b/mysql/docker-compose.yml
@@ -4,9 +4,12 @@ services:
   db:
     image: mysql:latest
     volumes:
-      - "./data:/var/lib/mysql"
+      - dbdata:/var/lib/mysql
     restart: always
     ports:
       - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: password
+
+volumes:
+  dbdata:

--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -4,10 +4,13 @@ services:
   db:
     image: postgres:latest
     volumes:
-      - ./data:/var/lib/postgresql/data 
+      - dbdata:/var/lib/postgresql/data 
     ports:
       - 5432:5432
     environment: 
       POSTGRES_USER: "root"
       POSTGRES_PASSWORD: "password"
     
+volumes:
+  dbdata:
+


### PR DESCRIPTION
The main issue I have with using local directories for container persistence is that 

1. Files created are owned by root.
1. The files are typically binary and not editable or interesting to a programmer in any way
1. Random "data" directories just a bit ugly in the filesystem :-(

I have discovered that docker-compose can hand-off the management of volumes to the docker engine instead. For example after running the examples associated with this PR, you can see that Docker has created 3 volumes:

```
$ docker volume list
DRIVER              VOLUME NAME
local               mongo_dbdata
local               mysql_dbdata
local               postgres_dbdata
```

To conclude I like how this approach elegantly hides away the messy details of persistence. Easy to cleanup the volume used by passing the "-v" option

```
docker-compose down -v
``` 