### PR TITLE
Update TiDB TiKV default config so it use less storage

### DIFF
--- a/tidb/config/tikv.toml
+++ b/tidb/config/tikv.toml
@@ -101,6 +101,8 @@ log-level = "error"
 # the "scheduler too busy" error is displayed.
 # scheduler-pending-write-threshold = "100MB"
 
+reserve-space = "0MB"
+
 [pd]
 # pd endpoints
 # endpoints = []


### PR DESCRIPTION
normally it would took 24GB preallocated disk space, now only 353MB