### PR TITLE
Change ClickHouse Docker repository.

### DIFF
--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -17,4 +17,4 @@ clickhouse-client
 
 ## Other docs
 
-[clickhouse server docker](https://hub.docker.com/r/yandex/clickhouse-server/)
+[clickhouse server docker](https://hub.docker.com/r/clickhouse/clickhouse-server/)


### PR DESCRIPTION
New versions are located in clickhouse/clickhouse-server only.