### PR TITLE
Set DB location for Postgres 18+

### DIFF
--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -4,13 +4,13 @@ services:
   db:
     image: postgres:latest
     volumes:
-      - dbdata:/var/lib/postgresql/data 
+      - dbdata:/var/lib/postgresql
     ports:
       - 5432:5432
-    environment: 
+    environment:
       POSTGRES_USER: "root"
       POSTGRES_PASSWORD: "password"
-    
+
 volumes:
   dbdata:
 


### PR DESCRIPTION
Starting with Postgres 18, Postgres won't start if a directory `/var/lib/postgresql/data` exists. It will show the following message before exiting:

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).  This better reflects how
       PostgreSQL itself works, and how upgrades are to be performed.

       See also https://github.com/docker-library/postgres/pull/1259

       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)

       This is usually the result of upgrading the Docker image without
       upgrading the underlying database using "pg_upgrade" (which requires both
       versions).

       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory, allowing usage of "pg_upgrade --link" without mount point
       boundary issues.

       See https://github.com/docker-library/postgres/issues/37 for a (long)
       discussion around this process, and suggestions for how to do so.
```

To avoid this, we set `dbdata` to `/var/lib/postgresql`. Postgres will then work, and will store data in directories such as `/var/lib/postgresql/18`, etc, depending on its version number.